### PR TITLE
Jenkins hosting compliance fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
         <relativePath />
     </parent>
     <groupId>io.split.jenkins.plugins</groupId>
-    <artifactId>split-plugin</artifactId>
+    <artifactId>split-admin</artifactId>
     <version>1.0</version>
     <packaging>hpi</packaging>
     <properties>
@@ -21,7 +21,8 @@
           ~ stapler-plugin.version: The Stapler Maven plugin version required by the plugin.
      -->
     </properties>
-    <name>Split plugin for Jenkins</name>
+    <name>Split Admin plugin for Jenkins</name>
+    <description>plugin that uses Split Admin REST API to allow creating,  updating and deleting Splits as part of Test automation and build workflow.</description>
     <!-- The default licence for Jenkins OSS Plugins is MIT. Substitute for the applicable one if needed. -->
     <licenses>
         <license>

--- a/src/main/java/io/split/jenkins/plugins/SplitAPI.java
+++ b/src/main/java/io/split/jenkins/plugins/SplitAPI.java
@@ -21,6 +21,7 @@ import org.apache.log4j.Logger;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
+import hudson.util.Secret;
 
 import java.io.IOException;
 import java.lang.reflect.Array;
@@ -28,6 +29,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.List;
+
 
 /**
 * Class wrapper for Split Admin API
@@ -39,13 +41,13 @@ public class SplitAPI {
 
     private static Logger _log = Logger.getLogger(SplitAPI.class);
 
-    private String _apiKey = "";
+    private Secret _apiKey = Secret.fromString("");
     private String _adminBaseURL = "";
     private final int _httpError = -1;
     private Map<String, String> _workspaces = new HashMap<>();
     private Map<String, List<String>> _environments = new HashMap<>();
 
-    SplitAPI(String adminApiKey, String adminBaseURL) {
+    SplitAPI(Secret adminApiKey, String adminBaseURL) {
         _apiKey = adminApiKey;
         _adminBaseURL = adminBaseURL;
     }
@@ -89,7 +91,7 @@ public class SplitAPI {
     private Header[] getHeaders() {
         Header[] headers = {
                 new BasicHeader("Content-type" , "application/json"),
-                new BasicHeader("Authorization", "Bearer " + _apiKey)
+            new BasicHeader("Authorization", "Bearer " + Secret.toString(_apiKey))
         };
         return headers;
     }

--- a/src/main/java/io/split/jenkins/plugins/SplitPluginBuilder.java
+++ b/src/main/java/io/split/jenkins/plugins/SplitPluginBuilder.java
@@ -5,6 +5,7 @@ import hudson.Launcher;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.util.FormValidation;
+import hudson.util.Secret;
 import hudson.model.AbstractProject;
 import hudson.model.Run;
 import hudson.model.TaskListener;
@@ -37,7 +38,7 @@ public class SplitPluginBuilder extends Builder implements SimpleBuildStep {
     private final String treatmentName;
     private final String whitelistKey;
     private final String splitYAMLFile;
-    private String apiKey;
+    private Secret apiKey;
     private String adminBaseURL;
     private static Logger _log = Logger.getLogger(SplitAPI.class);
     private String splitYAMLFileFullPath = "";
@@ -135,7 +136,7 @@ public class SplitPluginBuilder extends Builder implements SimpleBuildStep {
         return splitTask;
     }
 
-    public void setApiKey(String splitApiKey) {
+    public void setApiKey(Secret splitApiKey) {
         this.apiKey = splitApiKey;
     }
 
@@ -154,7 +155,7 @@ public class SplitPluginBuilder extends Builder implements SimpleBuildStep {
         }
         _log.info("Selected Task: " + splitTask);
         listener.getLogger().println("Selected Task: " + splitTask);
-        if (this.apiKey.equals("")) {
+        if (this.apiKey.equals(Secret.fromString(""))) {
             this.apiKey = DescriptorImpl.getSplitAdminApiKey();
         }
         if (this.adminBaseURL.equals("")) {
@@ -204,18 +205,18 @@ public class SplitPluginBuilder extends Builder implements SimpleBuildStep {
 
     }
     
-    @Symbol("greet")
+    @Symbol("split")
     @Extension
     public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
-        static String splitAdminApiKey = "";
+        static Secret splitAdminApiKey = Secret.fromString("");
         static String splitAdminBaseURL = "https://api.split.io/internal/api/v2";
 
-        public static String getSplitAdminApiKey() {
+        public static Secret getSplitAdminApiKey() {
             return splitAdminApiKey;
         }
         
         public static void setSplitAdminApiKey(String splitApiKey) {
-            splitAdminApiKey = splitApiKey;
+            splitAdminApiKey = Secret.fromString(splitApiKey);
         }
         
         public static String getAdminBaseURL() {

--- a/src/main/java/io/split/jenkins/plugins/YAMLParser.java
+++ b/src/main/java/io/split/jenkins/plugins/YAMLParser.java
@@ -2,6 +2,7 @@ package io.split.jenkins.plugins;
 
 import org.apache.log4j.Logger;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -24,7 +25,7 @@ public class YAMLParser {
     static Split[] readSplitsFromYAML(String YAMLFile) throws Exception {
         List<Split> splits = new ArrayList<Split>();
         try {
-            Yaml yaml = new Yaml();
+            Yaml yaml = new Yaml(new SafeConstructor());
             List<Map<String, HashMap<String, Object>>> yamlSplits = yaml.load(new InputStreamReader(new FileInputStream(YAMLFile), "UTF-8"));
             for (Map<String, HashMap<String, Object>> aSplit : yamlSplits) {
                 // The outter map is a map with one key, the split name

--- a/src/test/java/io/split/jenkins/plugins/SplitPluginBuilderTest.java
+++ b/src/test/java/io/split/jenkins/plugins/SplitPluginBuilderTest.java
@@ -3,6 +3,7 @@ package io.split.jenkins.plugins;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Label;
+import hudson.util.Secret;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -21,7 +22,7 @@ public class SplitPluginBuilderTest {
     @Rule
     public JenkinsRule jenkins = new JenkinsRule();
     final String adminBaseURL = "https://api.split.io/internal/api/v2";
-    final String splitAdminApi = "ADMIN API KEY";
+    String splitAdminApi = "";
     final String[] splitName = new String[] {"SplitPlugin_Jenkins_Test",  "SplitPlugin_Jenkins_Test", "SplitPlugin_Jenkins_Test",  "SplitPlugin_Jenkins_Test", "SplitPlugin_Jenkins_Test",  "SplitPlugin_Jenkins_Test"};
     final String[] workspaceName = new String[] {"Default", "Default", "Default", "Default", "Default", "Default", "Default"};
     final String[] environmentName = new String[] {"Production", "Production", "Production", "Production", "Production"};
@@ -115,7 +116,7 @@ public class SplitPluginBuilderTest {
     private SplitPluginBuilder prepareBuilder(String splitTask, String[] splitName, String[] environmentName, String[] workspaceName, String[] trafficTypeName, String splitDefinitions, String whitelistKey, String treatmentName, String splitYAMLFile) {
         
         SplitPluginBuilder tempBuilder = new SplitPluginBuilder(splitTask, splitName,  environmentName, workspaceName, trafficTypeName, splitDefinitions,  whitelistKey, treatmentName, splitYAMLFile);
-        tempBuilder.setApiKey(splitAdminApi);
+        tempBuilder.setApiKey(Secret.fromString(splitAdminApi));
         tempBuilder.setAdminBaseURL(adminBaseURL);
         return tempBuilder;
     }


### PR DESCRIPTION
- Used hudson.util.Secret to store the APi Key
- Updated plugin name to split-admin in pom.xml
- Update @Symbol to split
- Used SafeConstructor for yaml intialization.